### PR TITLE
Add CSDescription

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -60,9 +60,12 @@ class _HomeScreenState extends State<HomeScreen> {
             style: CSWidgetStyle(icon: Icon(FontAwesomeIcons.sun)),
           ),
           CSHeader('Selection'),
-          CSSelection(
-            ['Day mode', 'Night mode'],
-            (int value) {
+          CSSelection<int>(
+            [
+              CSSelectionItem<int>(text: 'Day mode', value: 0),
+              CSSelectionItem<int>(text: 'Night mode', value: 1),
+            ],
+            (value) {
               setState(() {
                 _index = value;
               });

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -69,6 +69,7 @@ class _HomeScreenState extends State<HomeScreen> {
             },
             currentSelection: _index,
           ),
+          CSDescription('Using Night mode extends battery life on devices with OLED display'),
           CSHeader(""),
           CSControl('Loading...', CupertinoActivityIndicator()),
           CSButton(CSButtonType.DEFAULT, "Licenses", () {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,15 +35,18 @@ class _HomeScreenState extends State<HomeScreen> {
         items: <Widget>[
           CSHeader('Brightness'),
           CSWidget(
-              new CupertinoSlider(
-                value: _slider,
-                onChanged: (double value) {
-                  setState(() {
-                    _slider = value;
-                  });
-                },
-              ),
-              style: CSWidgetStyle(icon: Icon(FontAwesomeIcons.sun))),
+            CupertinoSlider(
+              value: _slider,
+              onChanged: (double value) {
+                setState(() {
+                  _slider = value;
+                });
+              },
+            ),
+            style: CSWidgetStyle(
+              icon: Icon(FontAwesomeIcons.sun),
+            ),
+          ),
           CSControl(
             'Auto brightness',
             CupertinoSwitch(

--- a/lib/flutter_cupertino_settings.dart
+++ b/lib/flutter_cupertino_settings.dart
@@ -9,6 +9,7 @@ part 'widgets/description.dart';
 part 'widgets/header.dart';
 part 'widgets/link.dart';
 part 'widgets/selection.dart';
+part 'widgets/spacer.dart';
 part 'widgets/widget.dart';
 
 const double CS_ITEM_HEIGHT = 50.0;

--- a/lib/flutter_cupertino_settings.dart
+++ b/lib/flutter_cupertino_settings.dart
@@ -13,6 +13,7 @@ part 'widgets/spacer.dart';
 part 'widgets/widget.dart';
 
 const double CS_ITEM_HEIGHT = 50.0;
+const double CS_BORDER_HEIGHT = 0.45;
 const Color CS_HEADER_COLOR = Color(0xFFEEEEF3);
 const Color CS_BORDER_COLOR = Colors.black12;
 const Color CS_TEXT_COLOR = Colors.black;

--- a/lib/flutter_cupertino_settings.dart
+++ b/lib/flutter_cupertino_settings.dart
@@ -5,6 +5,7 @@ import 'package:flutter/cupertino.dart';
 
 part 'widgets/button.dart';
 part 'widgets/control.dart';
+part 'widgets/description.dart';
 part 'widgets/header.dart';
 part 'widgets/link.dart';
 part 'widgets/selection.dart';
@@ -17,6 +18,7 @@ const Color CS_TEXT_COLOR = Colors.black;
 const Color CS_HEADER_TEXT_COLOR = Colors.black54;
 const EdgeInsets CS_ITEM_PADDING = EdgeInsets.only(left: 10.0, right: 10.0);
 const double CS_HEADER_FONT_SIZE = 14.0;
+const double CS_DESCRIPTION_FONT_SIZE = 13.0;
 const double CS_ITEM_NAME_SIZE = 15.0;
 const EdgeInsets CS_ICON_PADDING = EdgeInsets.only(right: 10.0);
 const CSWidgetStyle CS_DEFAULT_STYLE = CSWidgetStyle();
@@ -25,6 +27,10 @@ const double CS_CHECK_SIZE = 16.0;
 
 /// Event for [CSSelection]
 typedef void SelectionCallback(int selected);
+
+/// Simple help function for determining the theme brightness
+bool _isDark(BuildContext context) =>
+    CupertinoTheme.of(context).brightness == Brightness.dark || Theme.of(context).brightness == Brightness.dark;
 
 class CupertinoSettings extends StatelessWidget {
   final List<Widget> items;
@@ -39,9 +45,7 @@ class CupertinoSettings extends StatelessWidget {
   Widget build(BuildContext context) {
     if (!shrinkWrap) {
       return Container(
-        color: Theme.of(context).brightness == Brightness.dark
-            ? Colors.black12
-            : CupertinoColors.lightBackgroundGray,
+        color: _isDark(context) ? Colors.black12 : CupertinoColors.lightBackgroundGray,
         child: SafeArea(
           bottom: false,
           child: Column(
@@ -61,9 +65,7 @@ class CupertinoSettings extends StatelessWidget {
       );
     }
     return Container(
-      color: Theme.of(context).brightness == Brightness.dark
-          ? Colors.black12
-          : CupertinoColors.lightBackgroundGray,
+      color: _isDark(context) ? Colors.black12 : CupertinoColors.lightBackgroundGray,
       child: SafeArea(
         bottom: false,
         child: ListView.builder(

--- a/lib/widgets/button.dart
+++ b/lib/widgets/button.dart
@@ -26,38 +26,39 @@ class CSButton extends CSWidget {
   final double fontSize;
 
   CSButton(this.type, this.text, this.pressed,
-      {CSWidgetStyle style = CS_DEFAULT_STYLE,
-      this.fontSize = CS_HEADER_FONT_SIZE})
+      {CSWidgetStyle style = CS_DEFAULT_STYLE, this.fontSize = CS_HEADER_FONT_SIZE})
       : super(
-            Flex(
-              direction: Axis.horizontal,
-              children: <Widget>[
-                Expanded(
-                  child: CupertinoButton(
-                    padding: EdgeInsets.zero,
-                    child: Container(
-                      alignment: type.alignment,
-                      child: Text(text,
-                          style:
-                              TextStyle(color: type.color, fontSize: fontSize)),
+          Flex(
+            direction: Axis.horizontal,
+            children: <Widget>[
+              Expanded(
+                child: CupertinoButton(
+                  padding: EdgeInsets.zero,
+                  child: Container(
+                    alignment: type.alignment,
+                    child: Text(
+                      text,
+                      style: TextStyle(
+                        color: type.color,
+                        fontSize: fontSize,
+                      ),
                     ),
-                    onPressed: pressed,
                   ),
+                  onPressed: pressed,
                 ),
-              ],
-            ),
-            style: style);
+              ),
+            ],
+          ),
+          style: style,
+        );
 }
 
 /// Defines different types for [CSButton]
 /// Specifies color and alignment
 class CSButtonType {
-  static const CSButtonType DESTRUCTIVE =
-      CSButtonType(Colors.red, AlignmentDirectional.center);
-  static const CSButtonType DEFAULT =
-      CSButtonType(Colors.blue, AlignmentDirectional.centerStart);
-  static const CSButtonType DEFAULT_CENTER =
-      CSButtonType(Colors.blue, AlignmentDirectional.center);
+  static const CSButtonType DESTRUCTIVE = CSButtonType(Colors.red, AlignmentDirectional.center);
+  static const CSButtonType DEFAULT = CSButtonType(Colors.blue, AlignmentDirectional.centerStart);
+  static const CSButtonType DEFAULT_CENTER = CSButtonType(Colors.blue, AlignmentDirectional.center);
 
   final Color color;
   final AlignmentGeometry alignment;

--- a/lib/widgets/control.dart
+++ b/lib/widgets/control.dart
@@ -14,12 +14,13 @@ class CSControl extends CSWidget {
     CSWidgetStyle style = CS_DEFAULT_STYLE,
     this.fontSize = CS_HEADER_FONT_SIZE,
   }) : super(
-            _ControlWidget(
-              fontSize: fontSize,
-              contentWidget: contentWidget,
-              name: name,
-            ),
-            style: style);
+          _ControlWidget(
+            fontSize: fontSize,
+            contentWidget: contentWidget,
+            name: name,
+          ),
+          style: style,
+        );
 }
 
 class _ControlWidget extends StatelessWidget {
@@ -39,13 +40,13 @@ class _ControlWidget extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: <Widget>[
-        Text(name,
-            style: TextStyle(
-              color: Theme.of(context).brightness == Brightness.dark
-                  ? null
-                  : CS_TEXT_COLOR,
-              fontSize: fontSize,
-            )),
+        Text(
+          name,
+          style: TextStyle(
+            color: _isDark(context) ? null : CS_TEXT_COLOR,
+            fontSize: fontSize,
+          ),
+        ),
         contentWidget
       ],
     );

--- a/lib/widgets/description.dart
+++ b/lib/widgets/description.dart
@@ -1,0 +1,31 @@
+part of flutter_cupertino_settings;
+
+class CSDescription extends StatelessWidget {
+  final String description;
+  final Color backgroundColorDark;
+
+  const CSDescription(
+    this.description, {
+    this.backgroundColorDark = Colors.black12,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(
+        10,
+        7.5,
+        5,
+        5,
+      ),
+      color: _isDark(context) ? backgroundColorDark : CS_HEADER_COLOR,
+      child: Text(
+        description,
+        style: TextStyle(
+          color: _isDark(context) ? null : CS_HEADER_TEXT_COLOR,
+          fontSize: CS_DESCRIPTION_FONT_SIZE,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/description.dart
+++ b/lib/widgets/description.dart
@@ -22,8 +22,9 @@ class CSDescription extends StatelessWidget {
       child: Text(
         description,
         style: TextStyle(
-          color: _isDark(context) ? null : CS_HEADER_TEXT_COLOR,
+          color: _isDark(context) ? CupertinoColors.lightBackgroundGray : CS_HEADER_TEXT_COLOR,
           fontSize: CS_DESCRIPTION_FONT_SIZE,
+          height: 1.1,
         ),
       ),
     );

--- a/lib/widgets/header.dart
+++ b/lib/widgets/header.dart
@@ -15,18 +15,22 @@ class CSHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.only(left: 10.0, top: 30.0, bottom: 5.0),
-      child: Text(title.toUpperCase(),
-          style: TextStyle(
-              color: Theme.of(context).brightness == Brightness.dark
-                  ? null
-                  : CS_HEADER_TEXT_COLOR,
-              fontSize: CS_HEADER_FONT_SIZE)),
+      child: Text(
+        title.toUpperCase(),
+        style: TextStyle(
+          color: _isDark(context) ? null : CS_HEADER_TEXT_COLOR,
+          fontSize: CS_HEADER_FONT_SIZE,
+        ),
+      ),
       decoration: BoxDecoration(
-          color: Theme.of(context).brightness == Brightness.dark
-              ? backgroundColorDark
-              : CS_HEADER_COLOR,
-          border:
-              Border(bottom: BorderSide(color: CS_BORDER_COLOR, width: 1.0))),
+        color: _isDark(context) ? backgroundColorDark : CS_HEADER_COLOR,
+        border: Border(
+          bottom: BorderSide(
+            color: CS_BORDER_COLOR,
+            width: 1.0,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/widgets/header.dart
+++ b/lib/widgets/header.dart
@@ -26,7 +26,8 @@ class CSHeader extends StatelessWidget {
         color: _isDark(context) ? backgroundColorDark : CS_HEADER_COLOR,
         border: Border(
           bottom: BorderSide(
-            color:  _isDark(context) ? CupertinoColors.inactiveGray : CS_BORDER_COLOR,
+            color: _isDark(context) ? CupertinoColors.inactiveGray : CS_BORDER_COLOR,
+            width: CS_BORDER_HEIGHT,
           ),
         ),
       ),

--- a/lib/widgets/header.dart
+++ b/lib/widgets/header.dart
@@ -26,8 +26,7 @@ class CSHeader extends StatelessWidget {
         color: _isDark(context) ? backgroundColorDark : CS_HEADER_COLOR,
         border: Border(
           bottom: BorderSide(
-            color: CS_BORDER_COLOR,
-            width: 1.0,
+            color:  _isDark(context) ? CupertinoColors.inactiveGray : CS_BORDER_COLOR,
           ),
         ),
       ),

--- a/lib/widgets/link.dart
+++ b/lib/widgets/link.dart
@@ -5,9 +5,15 @@ class CSLink extends CSWidget {
   final String text;
   final VoidCallback pressed;
   final double fontSize;
+  final bool useDarkForegroundColor;
 
-  CSLink(this.text, this.pressed, {CSWidgetStyle style = CS_DEFAULT_STYLE, this.fontSize = CS_HEADER_FONT_SIZE})
-      : super(
+  CSLink(
+    this.text,
+    this.pressed, {
+    this.useDarkForegroundColor = false,
+    CSWidgetStyle style = CS_DEFAULT_STYLE,
+    this.fontSize = CS_HEADER_FONT_SIZE,
+  }) : super(
           CupertinoButton(
             padding: EdgeInsets.zero,
             child: Row(
@@ -16,11 +22,14 @@ class CSLink extends CSWidget {
                 Text(
                   text,
                   style: TextStyle(
-                    color: CS_TEXT_COLOR,
+                    color: useDarkForegroundColor ? CupertinoColors.extraLightBackgroundGray : CS_TEXT_COLOR,
                     fontSize: fontSize,
                   ),
                 ),
-                const Icon(Icons.keyboard_arrow_right, color: Colors.black26)
+                Icon(
+                  Icons.keyboard_arrow_right,
+                  color: useDarkForegroundColor ? CupertinoColors.extraLightBackgroundGray : Colors.black26,
+                ),
               ],
             ),
             onPressed: pressed,

--- a/lib/widgets/link.dart
+++ b/lib/widgets/link.dart
@@ -6,24 +6,25 @@ class CSLink extends CSWidget {
   final VoidCallback pressed;
   final double fontSize;
 
-  CSLink(this.text, this.pressed,
-      {CSWidgetStyle style = CS_DEFAULT_STYLE,
-      this.fontSize = CS_HEADER_FONT_SIZE})
+  CSLink(this.text, this.pressed, {CSWidgetStyle style = CS_DEFAULT_STYLE, this.fontSize = CS_HEADER_FONT_SIZE})
       : super(
-            CupertinoButton(
-                padding: EdgeInsets.zero,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: <Widget>[
-                    Text(text,
-                        style: TextStyle(
-                          color: CS_TEXT_COLOR,
-                          fontSize: fontSize,
-                        )),
-                    const Icon(Icons.keyboard_arrow_right,
-                        color: Colors.black26)
-                  ],
+          CupertinoButton(
+            padding: EdgeInsets.zero,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Text(
+                  text,
+                  style: TextStyle(
+                    color: CS_TEXT_COLOR,
+                    fontSize: fontSize,
+                  ),
                 ),
-                onPressed: pressed),
-            style: style);
+                const Icon(Icons.keyboard_arrow_right, color: Colors.black26)
+              ],
+            ),
+            onPressed: pressed,
+          ),
+          style: style,
+        );
 }

--- a/lib/widgets/link.dart
+++ b/lib/widgets/link.dart
@@ -1,39 +1,43 @@
 part of flutter_cupertino_settings;
 
 /// Provides a button for navigation
-class CSLink extends CSWidget {
+class CSLink extends StatelessWidget {
   final String text;
   final VoidCallback pressed;
   final double fontSize;
-  final bool useDarkForegroundColor;
+  final CSWidgetStyle style;
 
   CSLink(
     this.text,
     this.pressed, {
-    this.useDarkForegroundColor = false,
-    CSWidgetStyle style = CS_DEFAULT_STYLE,
+    this.style = CS_DEFAULT_STYLE,
     this.fontSize = CS_HEADER_FONT_SIZE,
-  }) : super(
-          CupertinoButton(
-            padding: EdgeInsets.zero,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: <Widget>[
-                Text(
-                  text,
-                  style: TextStyle(
-                    color: useDarkForegroundColor ? CupertinoColors.extraLightBackgroundGray : CS_TEXT_COLOR,
-                    fontSize: fontSize,
-                  ),
-                ),
-                Icon(
-                  Icons.keyboard_arrow_right,
-                  color: useDarkForegroundColor ? CupertinoColors.extraLightBackgroundGray : Colors.black26,
-                ),
-              ],
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return CSWidget(
+      CupertinoButton(
+        padding: EdgeInsets.zero,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: <Widget>[
+            Text(
+              text,
+              style: TextStyle(
+                color: _isDark(context) ? CupertinoColors.extraLightBackgroundGray : CS_TEXT_COLOR,
+                fontSize: fontSize,
+              ),
             ),
-            onPressed: pressed,
-          ),
-          style: style,
-        );
+            Icon(
+              Icons.keyboard_arrow_right,
+              color: _isDark(context) ? CupertinoColors.extraLightBackgroundGray : Colors.black26,
+            ),
+          ],
+        ),
+        onPressed: pressed,
+      ),
+      style: style,
+    );
+  }
 }

--- a/lib/widgets/selection.dart
+++ b/lib/widgets/selection.dart
@@ -41,13 +41,6 @@ class CSSelectionState<T> extends State<CSSelection> {
 
   @override
   Widget build(BuildContext context) {
-    // final List<Widget> widgets = <Widget>[];
-    // for (int i = 0; i < items.length; i++) {
-    //   widgets.add(createItem(context, items[i]));
-    // }
-
-    // return Column(children: widgets);
-
     return Column(
       children: items.map<CSWidget>((item) => createItem(context, item)).toList(),
     );

--- a/lib/widgets/selection.dart
+++ b/lib/widgets/selection.dart
@@ -11,50 +11,55 @@ part of flutter_cupertino_settings;
 /// select "world"
 ///
 /// onSelected(1)
-class CSSelection extends StatefulWidget {
-  final List<String> items;
-  final SelectionCallback onSelected;
-  final int currentSelection;
+
+class CSSelection<T> extends StatefulWidget {
+  final List<CSSelectionItem> items;
+  final void Function(T selected) onSelected;
+  final T currentSelection;
   final double fontSize;
 
   CSSelection(
     this.items,
     this.onSelected, {
-    this.currentSelection = 0,
+    this.currentSelection,
     this.fontSize = CS_HEADER_FONT_SIZE,
   });
 
   @override
   State<StatefulWidget> createState() {
-    return CSSelectionState(items, currentSelection, onSelected);
+    return CSSelectionState<T>(items, currentSelection ?? items.first.value, onSelected);
   }
 }
 
 /// [State] for [CSSelection]
-class CSSelectionState extends State<CSSelection> {
-  int currentSelection;
-  final SelectionCallback onSelected;
-  final List<String> items;
+class CSSelectionState<T> extends State<CSSelection> {
+  T currentSelection;
+  final void Function(T selected) onSelected;
+  final List<CSSelectionItem> items;
 
   CSSelectionState(this.items, this.currentSelection, this.onSelected);
 
   @override
   Widget build(BuildContext context) {
-    final List<Widget> widgets = <Widget>[];
-    for (int i = 0; i < items.length; i++) {
-      widgets.add(createItem(context, items[i], i));
-    }
+    // final List<Widget> widgets = <Widget>[];
+    // for (int i = 0; i < items.length; i++) {
+    //   widgets.add(createItem(context, items[i]));
+    // }
 
-    return Column(children: widgets);
+    // return Column(children: widgets);
+
+    return Column(
+      children: items.map<CSWidget>((item) => createItem(context, item)).toList(),
+    );
   }
 
-  Widget createItem(BuildContext context, String name, int index) {
+  Widget createItem(BuildContext context, CSSelectionItem item) {
     return CSWidget(
       CupertinoButton(
         onPressed: () {
-          if (index != currentSelection) {
-            setState(() => currentSelection = index);
-            onSelected(index);
+          if (item.value != currentSelection) {
+            setState(() => currentSelection = item.value);
+            onSelected(item.value);
           }
         },
         pressedOpacity: 1.0,
@@ -62,7 +67,7 @@ class CSSelectionState extends State<CSSelection> {
           children: <Widget>[
             Expanded(
               child: Text(
-                name,
+                item.text,
                 style: TextStyle(
                   color: _isDark(context) ? Colors.white : CS_TEXT_COLOR,
                   fontSize: widget.fontSize,
@@ -71,7 +76,9 @@ class CSSelectionState extends State<CSSelection> {
             ),
             Icon(
               Icons.check,
-              color: index == currentSelection ? _isDark(context) ? Colors.white : CS_CHECK_COLOR : Colors.transparent,
+              color: item.value == currentSelection
+                  ? _isDark(context) ? Colors.white : CS_CHECK_COLOR
+                  : Colors.transparent,
               size: CS_CHECK_SIZE,
             ),
           ],
@@ -79,4 +86,15 @@ class CSSelectionState extends State<CSSelection> {
       ),
     );
   }
+}
+
+class CSSelectionItem<T> {
+  final T value;
+  final String text;
+
+  const CSSelectionItem({
+    Key key,
+    this.value,
+    this.text,
+  });
 }

--- a/lib/widgets/selection.dart
+++ b/lib/widgets/selection.dart
@@ -17,8 +17,12 @@ class CSSelection extends StatefulWidget {
   final int currentSelection;
   final double fontSize;
 
-  CSSelection(this.items, this.onSelected,
-      {this.currentSelection = 0, this.fontSize = CS_HEADER_FONT_SIZE});
+  CSSelection(
+    this.items,
+    this.onSelected, {
+    this.currentSelection = 0,
+    this.fontSize = CS_HEADER_FONT_SIZE,
+  });
 
   @override
   State<StatefulWidget> createState() {
@@ -45,7 +49,8 @@ class CSSelectionState extends State<CSSelection> {
   }
 
   Widget createItem(BuildContext context, String name, int index) {
-    return CSWidget(new CupertinoButton(
+    return CSWidget(
+      CupertinoButton(
         onPressed: () {
           if (index != currentSelection) {
             setState(() => currentSelection = index);
@@ -56,23 +61,22 @@ class CSSelectionState extends State<CSSelection> {
         child: Row(
           children: <Widget>[
             Expanded(
-                child: Text(
-              name,
-              style: TextStyle(
-                color: Theme.of(context).brightness == Brightness.dark
-                    ? Colors.white
-                    : CS_TEXT_COLOR,
-                fontSize: widget.fontSize,
+              child: Text(
+                name,
+                style: TextStyle(
+                  color: _isDark(context) ? Colors.white : CS_TEXT_COLOR,
+                  fontSize: widget.fontSize,
+                ),
               ),
-            )),
-            Icon(Icons.check,
-                color: (index == currentSelection
-                    ? Theme.of(context).brightness == Brightness.dark
-                        ? Colors.white
-                        : CS_CHECK_COLOR
-                    : Colors.transparent),
-                size: CS_CHECK_SIZE)
+            ),
+            Icon(
+              Icons.check,
+              color: index == currentSelection ? _isDark(context) ? Colors.white : CS_CHECK_COLOR : Colors.transparent,
+              size: CS_CHECK_SIZE,
+            ),
           ],
-        )));
+        ),
+      ),
+    );
   }
 }

--- a/lib/widgets/spacer.dart
+++ b/lib/widgets/spacer.dart
@@ -1,0 +1,25 @@
+part of flutter_cupertino_settings;
+
+class CSSpacer extends StatelessWidget {
+  final Color backgroundColorDark;
+
+  const CSSpacer({
+    Key key,
+    this.backgroundColorDark = Colors.black12,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.only(left: 10.0, top: 30.0, bottom: 5.0),
+      decoration: BoxDecoration(
+        color: _isDark(context) ? backgroundColorDark : CS_HEADER_COLOR,
+        border: Border(
+          bottom: BorderSide(
+            color: _isDark(context) ? CupertinoColors.inactiveGray : CS_BORDER_COLOR,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/spacer.dart
+++ b/lib/widgets/spacer.dart
@@ -2,10 +2,12 @@ part of flutter_cupertino_settings;
 
 class CSSpacer extends StatelessWidget {
   final Color backgroundColorDark;
+  final bool showBorder;
 
   const CSSpacer({
     Key key,
     this.backgroundColorDark = Colors.black12,
+    this.showBorder = true,
   }) : super(key: key);
 
   @override
@@ -15,9 +17,11 @@ class CSSpacer extends StatelessWidget {
       decoration: BoxDecoration(
         color: _isDark(context) ? backgroundColorDark : CS_HEADER_COLOR,
         border: Border(
-          bottom: BorderSide(
-            color: _isDark(context) ? CupertinoColors.inactiveGray : CS_BORDER_COLOR,
-          ),
+          bottom: showBorder
+              ? BorderSide(
+                  color: _isDark(context) ? CupertinoColors.inactiveGray : CS_BORDER_COLOR,
+                )
+              : BorderSide.none,
         ),
       ),
     );

--- a/lib/widgets/spacer.dart
+++ b/lib/widgets/spacer.dart
@@ -20,6 +20,7 @@ class CSSpacer extends StatelessWidget {
           bottom: showBorder
               ? BorderSide(
                   color: _isDark(context) ? CupertinoColors.inactiveGray : CS_BORDER_COLOR,
+                  width: CS_BORDER_HEIGHT,
                 )
               : BorderSide.none,
         ),

--- a/lib/widgets/widget.dart
+++ b/lib/widgets/widget.dart
@@ -45,7 +45,7 @@ class CSWidget extends StatelessWidget {
         border: Border(
           bottom: BorderSide(
             color: _isDark(context) ? CupertinoColors.inactiveGray : CS_BORDER_COLOR,
-            width: _isDark(context) ? 0.5 : 1,
+            width: CS_BORDER_HEIGHT,
           ),
         ),
       ),

--- a/lib/widgets/widget.dart
+++ b/lib/widgets/widget.dart
@@ -35,17 +35,20 @@ class CSWidget extends StatelessWidget {
     }
 
     return Container(
-        alignment: alignment,
-        height: height,
-        padding: CS_ITEM_PADDING,
-        decoration: BoxDecoration(
-          color: Theme.of(context).brightness == Brightness.dark
-              ? null
-              : Colors.white,
-          border:
-              Border(bottom: BorderSide(color: CS_BORDER_COLOR, width: 1.0)),
+      alignment: alignment,
+      height: height,
+      padding: CS_ITEM_PADDING,
+      decoration: BoxDecoration(
+        color: _isDark(context) ? null : Colors.white,
+        border: Border(
+          bottom: BorderSide(
+            color: CS_BORDER_COLOR,
+            width: 1.0,
+          ),
         ),
-        child: child);
+      ),
+      child: child,
+    );
   }
 }
 

--- a/lib/widgets/widget.dart
+++ b/lib/widgets/widget.dart
@@ -23,13 +23,15 @@ class CSWidget extends StatelessWidget {
 
     //style.icon
     if (style.icon != null) {
-      child = Row(children: <Widget>[
-        Container(
-          child: style.icon,
-          padding: CS_ICON_PADDING,
-        ),
-        Expanded(child: widget)
-      ]);
+      child = Row(
+        children: <Widget>[
+          Container(
+            child: style.icon,
+            padding: CS_ICON_PADDING,
+          ),
+          Expanded(child: widget)
+        ],
+      );
     } else {
       child = widget;
     }
@@ -39,11 +41,11 @@ class CSWidget extends StatelessWidget {
       height: height,
       padding: CS_ITEM_PADDING,
       decoration: BoxDecoration(
-        color: _isDark(context) ? null : Colors.white,
+        color: _isDark(context) ? CupertinoColors.darkBackgroundGray : CupertinoColors.white,
         border: Border(
           bottom: BorderSide(
-            color: CS_BORDER_COLOR,
-            width: 1.0,
+            color: _isDark(context) ? CupertinoColors.inactiveGray : CS_BORDER_COLOR,
+            width: _isDark(context) ? 0.5 : 1,
           ),
         ),
       ),

--- a/readme.md
+++ b/readme.md
@@ -20,18 +20,19 @@ CSWidgetStyle brightnessStyle = const CSWidgetStyle(
     icon: const Icon(Icons.brightness_medium, color: Colors.black54)
 );
 
-new CupertinoSettings(
+CupertinoSettings(
     items: <Widget>[
-        new CSHeader('Brightness'),
-        new CSWidget(new CupertinoSlider(value: 0.5), style: brightnessStyle),
-        new CSControl('Auto brightness', new CupertinoSwitch(value: true), style: brightnessStyle,),
-        new CSHeader('Selection'),
-        new CSSelection(['Day mode','Night mode'], (index) {print(index);}, currentSelection: 0),
-        new CSHeader(),
-        new CSControl('Loading...', new CupertinoActivityIndicator()),
-        new CSButton(CSButtonType.DEFAULT, "Licenses", (){ print("It works!"); }),
-        new CSHeader(),
-        new CSButton(CSButtonType.DESTRUCTIVE, "Delete all data", (){})
+        CSHeader('Brightness'),
+        CSWidget(CupertinoSlider(value: 0.5), style: brightnessStyle),
+        CSControl('Auto brightness', CupertinoSwitch(value: true), style: brightnessStyle,),
+        CSHeader('Selection'),
+        CSSelection(['Day mode','Night mode'], (index) {print(index);}, currentSelection: 0),
+        CSDescription('Using Night mode extends battery life on devices with OLED display'),
+        CSHeader(),
+        CSControl('Loading...', CupertinoActivityIndicator()),
+        CSButton(CSButtonType.DEFAULT, "Licenses", (){ print("It works!"); }),
+        CSHeader(),
+        CSButton(CSButtonType.DESTRUCTIVE, "Delete all data", (){})
     ]
 );
 ```


### PR DESCRIPTION
I've add the CSDescription widget, to show a description or details under a Setting. I've also adding trailing commas to the code to improve the readability. 
Last little change, is the _isDark function which gets the context and looks if the CupertinoTheme brightness or the MaterialTheme brightness is dark. So it is now possible to use this package without MaterialApp in the WidgetTree.