### PR TITLE
Update cupertino_icons to 1.0.0

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^1.0.0
   # cupertino_icons:
   #   git:
   #     url: https://github.com/flutter/cupertino_icons.git

--- a/lib/flutter_cupertino_settings.dart
+++ b/lib/flutter_cupertino_settings.dart
@@ -31,7 +31,8 @@ const EdgeInsets CS_ICON_PADDING = EdgeInsets.only(
   left: 4.0,
 );
 const CSWidgetStyle CS_DEFAULT_STYLE = CSWidgetStyle();
-const double CS_CHECK_SIZE = 28.0;
+const double CS_CHECK_SIZE = 20.0;
+const double CS_CHEVRON_SIZE = 17.0;
 
 /// Event for [CSSelection]
 typedef void SelectionCallback(int selected);

--- a/lib/widgets/link.dart
+++ b/lib/widgets/link.dart
@@ -90,12 +90,17 @@ class CSLink extends StatelessWidget {
               ),
               const SizedBox(width: 4),
             ],
-            trailing ??
-                Icon(
-                  CupertinoIcons.right_chevron,
-                  color: CupertinoColors.secondaryLabel.resolveFrom(context),
-                  size: 20,
-                ),
+            Padding(
+              padding: const EdgeInsets.only(left: 1.0, right: 2.0),
+              child: trailing ??
+                  Icon(
+                    CupertinoIcons.right_chevron,
+                    color: CupertinoColors.secondaryLabel
+                        .resolveFrom(context)
+                        .withOpacity(0.4),
+                    size: CS_CHEVRON_SIZE,
+                  ),
+            ),
           ],
         ),
       ),

--- a/lib/widgets/selection.dart
+++ b/lib/widgets/selection.dart
@@ -76,12 +76,15 @@ class CSSelectionState<T> extends State<CSSelection> {
                 ),
               ),
             ),
-            Icon(
-              CupertinoIcons.check_mark,
-              color: item.value == currentSelection
-                  ? CupertinoColors.activeBlue
-                  : const Color(0x00000000),
-              size: CS_CHECK_SIZE,
+            Padding(
+              padding: const EdgeInsets.only(right: 5.0),
+              child: Icon(
+                CupertinoIcons.check_mark,
+                color: item.value == currentSelection
+                    ? CupertinoColors.activeBlue
+                    : const Color(0x00000000),
+                size: CS_CHECK_SIZE,
+              ),
             ),
           ],
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,5 +13,4 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cupertino_icons: ^0.1.3
-
+  cupertino_icons: ^1.0.0


### PR DESCRIPTION
**Before · After · Original**
<p float="left">
<img src="https://user-images.githubusercontent.com/519227/93726330-274df580-fbbe-11ea-9066-04b6283a27d5.png" width="33%">

<img src="https://user-images.githubusercontent.com/519227/93726334-2a48e600-fbbe-11ea-979a-5e9a91ef6b9a.png" width="33%">

<img src="https://user-images.githubusercontent.com/519227/93726423-9b889900-fbbe-11ea-85db-b77a0db36af3.jpeg" width="33%">
</p>

This PR ensures that developers will be able to use the package with [cupertino_icons](https://pub.dev/packages/cupertino_icons) 1.0+ and the upcoming versions of Flutter, which is otherwise complicated with failed version resolving.

Resolves #23.