### PR TITLE
Support subtitle for selection lists

### DIFF
--- a/lib/flutter_cupertino_settings.dart
+++ b/lib/flutter_cupertino_settings.dart
@@ -46,9 +46,11 @@ TextStyle basicTextStyle(BuildContext context) => kIsWeb
 class CupertinoSettings extends StatelessWidget {
   final List<Widget> items;
   final bool shrinkWrap;
+  final ScrollController scrollController;
 
   const CupertinoSettings({
     @required this.items,
+    this.scrollController,
     this.shrinkWrap = false,
   });
 
@@ -62,6 +64,7 @@ class CupertinoSettings extends StatelessWidget {
             ? ListView.builder(
                 shrinkWrap: shrinkWrap,
                 itemCount: items.length,
+                controller: scrollController,
                 itemBuilder: (BuildContext context, int index) => items[index],
               )
             : Column(
@@ -70,6 +73,7 @@ class CupertinoSettings extends StatelessWidget {
                     child: ListView.builder(
                       shrinkWrap: shrinkWrap,
                       itemCount: items.length,
+                      controller: scrollController,
                       itemBuilder: (BuildContext context, int index) =>
                           items[index],
                     ),

--- a/lib/flutter_cupertino_settings.dart
+++ b/lib/flutter_cupertino_settings.dart
@@ -37,19 +37,21 @@ const double CS_CHEVRON_SIZE = 17.0;
 /// Event for [CSSelection]
 typedef void SelectionCallback(int selected);
 
-TextStyle basicTextStyle(BuildContext context) => kIsWeb
-    ? Theme.of(context).textTheme.subhead
-    : Platform.isIOS
-        ? CupertinoTheme.of(context).textTheme.textStyle
-        : Theme.of(context).textTheme.subhead;
+TextStyle basicTextStyle(BuildContext context) =>
+    (kIsWeb
+        ? Theme.of(context).textTheme.subtitle2
+        : Platform.isIOS
+            ? CupertinoTheme.of(context).textTheme.textStyle
+            : Theme.of(context).textTheme.subtitle2) ??
+    TextStyle();
 
 class CupertinoSettings extends StatelessWidget {
   final List<Widget> items;
   final bool shrinkWrap;
-  final ScrollController scrollController;
+  final ScrollController? scrollController;
 
   const CupertinoSettings({
-    @required this.items,
+    required this.items,
     this.scrollController,
     this.shrinkWrap = false,
   });

--- a/lib/widgets/control.dart
+++ b/lib/widgets/control.dart
@@ -4,8 +4,8 @@ part of flutter_cupertino_settings;
 /// extends [CSWidget]
 /// Provides the correct paddings and text properties
 class CSControl extends CSWidget {
-  final Widget nameWidget;
-  final Widget contentWidget;
+  final Widget? nameWidget;
+  final Widget? contentWidget;
   final double fontSize;
 
   CSControl({
@@ -26,12 +26,12 @@ class CSControl extends CSWidget {
 }
 
 class _ControlWidget extends StatelessWidget {
-  final Widget nameWidget;
-  final Widget contentWidget;
-  final double fontSize;
+  final Widget? nameWidget;
+  final Widget? contentWidget;
+  final double? fontSize;
 
   const _ControlWidget({
-    Key key,
+    Key? key,
     this.fontSize,
     this.contentWidget,
     this.nameWidget,
@@ -47,8 +47,8 @@ class _ControlWidget extends StatelessWidget {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: <Widget>[
-          if (nameWidget != null) nameWidget,
-          if (contentWidget != null) contentWidget,
+          if (nameWidget != null) nameWidget!,
+          if (contentWidget != null) contentWidget!,
         ],
       ),
     );

--- a/lib/widgets/link.dart
+++ b/lib/widgets/link.dart
@@ -3,19 +3,19 @@ part of flutter_cupertino_settings;
 /// Provides a button for navigation
 class CSLink extends StatelessWidget {
   final String title;
-  final String subtitle;
-  final String detail;
-  final VoidCallback onPressed;
+  final String? subtitle;
+  final String? detail;
+  final VoidCallback? onPressed;
   final double titleFontSize;
   final double subTitleFontSize;
   final CSWidgetStyle style;
   final bool addPaddingToBorder;
   final bool showTopBorder;
-  final Widget trailing;
+  final Widget? trailing;
   final CellType cellType;
 
   const CSLink({
-    this.title,
+    required this.title,
     this.onPressed,
     this.subtitle,
     this.detail,
@@ -33,11 +33,11 @@ class CSLink extends StatelessWidget {
     final showSubtitle = (cellType == CellType.subtitleDetailStyle ||
             cellType == CellType.subtitleStyle) &&
         subtitle != null &&
-        subtitle.isNotEmpty;
+        subtitle!.isNotEmpty;
     final showDetail = (cellType == CellType.subtitleDetailStyle ||
             cellType == CellType.detailRightStyle) &&
         detail != null &&
-        detail.isNotEmpty;
+        detail!.isNotEmpty;
 
     return CSWidget(
       CupertinoButton(
@@ -65,7 +65,7 @@ class CSLink extends StatelessWidget {
                   if (showSubtitle) const SizedBox(height: 2),
                   if (showSubtitle)
                     Text(
-                      subtitle,
+                      subtitle!,
                       style: basicTextStyle(context).copyWith(
                         color:
                             CupertinoColors.secondaryLabel.resolveFrom(context),
@@ -80,7 +80,7 @@ class CSLink extends StatelessWidget {
             ),
             if (showDetail) ...[
               Text(
-                detail,
+                detail!,
                 style: basicTextStyle(context).copyWith(
                   color: CupertinoColors.secondaryLabel.resolveFrom(context),
                   fontSize: titleFontSize,

--- a/lib/widgets/selection.dart
+++ b/lib/widgets/selection.dart
@@ -33,6 +33,21 @@ class CSSelection<T> extends StatelessWidget {
   }
 
   Widget createItem(BuildContext context, CSSelectionItem<T> item) {
+    final text = Text(item.text,
+        style: TextStyle(
+          color: CupertinoColors.label.resolveFrom(context),
+          fontSize: fontSize,
+        ));
+    final textWidget = item.subtitle == null
+        ? text
+        : Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+            text,
+            SizedBox(height: 2),
+            Text(item.subtitle,
+                style: basicTextStyle(context).copyWith(
+                    color: CupertinoColors.secondaryLabel.resolveFrom(context),
+                    fontSize: CS_HEADER_FONT_SIZE))
+          ]);
     return CSWidget(
       CupertinoButton(
         onPressed: () {
@@ -40,19 +55,11 @@ class CSSelection<T> extends StatelessWidget {
           onSelected(item.value);
         },
         pressedOpacity: 1.0,
-        padding: const EdgeInsets.fromLTRB(4, 1, 2, 1),
+        padding: const EdgeInsets.fromLTRB(4, 8, 2, 8),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: <Widget>[
-            Expanded(
-              child: Text(
-                item.text,
-                style: TextStyle(
-                  color: CupertinoColors.label.resolveFrom(context),
-                  fontSize: fontSize,
-                ),
-              ),
-            ),
+            Expanded(child: textWidget),
             Padding(
               padding: const EdgeInsets.only(right: 5.0),
               child: Icon(
@@ -75,11 +82,13 @@ class CSSelection<T> extends StatelessWidget {
 class CSSelectionItem<T> {
   final T value;
   final String text;
+  final String subtitle;
   final bool showTopBorder;
 
   const CSSelectionItem({
     this.value,
     this.text,
+    this.subtitle,
     this.showTopBorder = false,
   });
 }

--- a/lib/widgets/selection.dart
+++ b/lib/widgets/selection.dart
@@ -15,12 +15,12 @@ part of flutter_cupertino_settings;
 class CSSelection<T> extends StatelessWidget {
   final List<CSSelectionItem<T>> items;
   final void Function(T selected) onSelected;
-  final T currentSelection;
+  final T? currentSelection;
   final double fontSize;
 
   const CSSelection({
-    this.items,
-    this.onSelected,
+    required this.items,
+    required this.onSelected,
     this.currentSelection,
     this.fontSize = CS_TITLE_FONT_SIZE,
   });
@@ -43,7 +43,7 @@ class CSSelection<T> extends StatelessWidget {
         : Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
             text,
             SizedBox(height: 2),
-            Text(item.subtitle,
+            Text(item.subtitle!,
                 style: basicTextStyle(context).copyWith(
                     color: CupertinoColors.secondaryLabel.resolveFrom(context),
                     fontSize: CS_HEADER_FONT_SIZE))
@@ -82,12 +82,12 @@ class CSSelection<T> extends StatelessWidget {
 class CSSelectionItem<T> {
   final T value;
   final String text;
-  final String subtitle;
+  final String? subtitle;
   final bool showTopBorder;
 
   const CSSelectionItem({
-    this.value,
-    this.text,
+    required this.value,
+    required this.text,
     this.subtitle,
     this.showTopBorder = false,
   });

--- a/lib/widgets/spacer.dart
+++ b/lib/widgets/spacer.dart
@@ -4,7 +4,7 @@ class CSSpacer extends StatelessWidget {
   final bool showBorder;
 
   const CSSpacer({
-    Key key,
+    Key? key,
     this.showBorder = true,
   }) : super(key: key);
 

--- a/lib/widgets/widget.dart
+++ b/lib/widgets/widget.dart
@@ -6,7 +6,7 @@ part of flutter_cupertino_settings;
 /// The optional [style] attribute allows to specify a style (e.g. an Icon)
 class CSWidget extends StatelessWidget {
   final Widget widget;
-  final AlignmentGeometry alignment;
+  final AlignmentGeometry? alignment;
   final double height;
   final CSWidgetStyle style;
   final bool addPaddingToBorder;
@@ -80,7 +80,7 @@ class CSWidget extends StatelessWidget {
 
 /// Defines style attributes that can be applied to every [CSWidget]
 class CSWidgetStyle {
-  final Icon icon;
+  final Icon? icon;
 
   const CSWidgetStyle({this.icon});
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,8 +7,7 @@ authors:
 homepage: https://github.com/matthinc/flutter_cupertino_settings
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
-  flutter: ">=1.12.13-hotfix.5 <2.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Support a secondary text field for to appear below the primary text of a
selection list item.

Also updated the `EdgeInsets` for the content, vertical insets changed
from 1 to 8. Otherwise the combined title and subtitle lack sufficient
padding from the item border. There is no change to the appearance of
items without a subtitle.

Below is appearance after these changes, with and without subtitle.

<img width=400 src="https://user-images.githubusercontent.com/102698/107041990-314c4b80-678f-11eb-9b4c-7c29415d7e6b.png" /> <img width=400 src="https://user-images.githubusercontent.com/102698/107041979-2e515b00-678f-11eb-95d8-c847d58a9a4b.png" />